### PR TITLE
Decrease padding between nav menu links

### DIFF
--- a/outreachyhome/static/css/main.css
+++ b/outreachyhome/static/css/main.css
@@ -102,7 +102,7 @@ h3 {
 
 .nav li {
     display: inline-block;
-    padding: 0 15px;
+    padding: 0 12px;
     line-height: 0px
 }
 


### PR DESCRIPTION
This prevents the menu from wrapping to a second line and covering up page content.

Resolves layout bug in #14.

I didn't need to touch the minified bootstrap css (#12) to make this work; I just updated main.css and did `./manage.py collectstatic`, and the change worked for me locally.