### PR TITLE
Minor improvements to formatting and grammar-y words

### DIFF
--- a/docs/onboarding-coordinator-flow.md
+++ b/docs/onboarding-coordinator-flow.md
@@ -355,11 +355,11 @@ Data to Gather
      * 11-20 people
      * 21-50 people
      * 50-100 people
-     * > 100 people
+     * more than 100 people
    * Does your project use an [OSI-approved open source license](https://opensource.org/licenses/alphabetical) or a [Creative Commons license](https://creativecommons.org/share-your-work/licensing-types-examples/)?
      * If no: Please detail your licenses, with links to license text.
  * Information for the applicants:
-   * Short title (nine words or less, assuming the person has never heard of your technology before, starting with an adverb like "Create", "Improve", "Extend", "Survey", "Document")
+   * Short title (nine words or less, assuming the person has never heard of your technology before, starting with a verb like "Create", "Improve", "Extend", "Survey", "Document")
    * Description
    * URL for project repository or contribution pages
    * URL for project issue/bug tracker


### PR DESCRIPTION
Markdown was messing with `> 100 people` making it look like a quote of "100 people", so I just rephrased to "more than 100 people".

I believe (and English is not my first language, so I could be wrong, but I did check wikipedia...) that "Create" is a verb, and that "creatively" would be an adverb. It's possible you want to be more specific than just "verb", but I'm not sure, so I didn't specify anything else.