### PR TITLE
Check permissions

### DIFF
--- a/home/models.py
+++ b/home/models.py
@@ -263,6 +263,9 @@ class Community(models.Model):
     def get_absolute_url(self):
         return reverse('community-read-only', kwargs={'slug': self.slug})
 
+    def is_coordinator(self, user):
+        return self.coordinatorapproval_set.filter(approved=True, coordinator__account=user).exists()
+
 class NewCommunity(Community):
     community = models.OneToOneField(Community, primary_key=True, parent_link=True)
 
@@ -431,6 +434,9 @@ class Project(models.Model):
                 community = self.project_round.community,
                 title = self.short_title,
                 )
+
+    def is_mentor(self, user):
+        return self.mentorapproval_set.filter(approved=True, mentor__account=user).exists()
 
 class ProjectSkill(models.Model):
     project = models.ForeignKey(Project, verbose_name="Project")

--- a/home/templates/home/project_read_only.html
+++ b/home/templates/home/project_read_only.html
@@ -76,7 +76,7 @@ Pending {{ community.name }} Project - {{ project.short_title }}
 	<p><strong>Unapproved Project Mentors:</strong></p>
 	{% for mentor in unapproved_mentors %}
 		<p>{{ mentor.public_name }} &lt;{{ mentor.account.email }}&gt;</p>
-		<form action="{% url 'project-mentor-status' community_slug=community.slug project_slug=project.slug mentor_id=mentor.account_id %}" method="post">
+		<form action="{% url 'project-mentor-status' community_slug=community.slug project_slug=project.slug mentor_id=mentor.pk %}" method="post">
 			{% csrf_token %}
 			<input class="btn btn-success" type="submit" name="approve" value="Approve Mentor" />
 			<input class="btn btn-warning" type="submit" name="reject" value="Reject Mentor" />
@@ -114,20 +114,18 @@ Pending {{ community.name }} Project - {{ project.short_title }}
 </ul>
 
 <p><strong>Project Mentors:</strong></p>
-{% if comrade and comrade in unapproved_mentors %}
-	<p>Your request to mentor this project is under review by the community coordinator.</p>
-	<form action="{% url 'project-mentor-status' community_slug=community.slug project_slug=project.slug mentor_id=comrade.account_id %}" method="post">
-		{% csrf_token %}
-		<input class="btn btn-warning" type="submit" name="reject" value="Withdraw From Mentoring" />
-	</form>
-{% elif comrade and comrade in approved_mentors %}
+{% if mentor_request %}
+	{% if mentor_request.approved is True %}
 	<p>You are an approved mentor for this project.</p>
-	<form action="{% url 'project-mentor-status' community_slug=community.slug project_slug=project.slug mentor_id=comrade.account_id %}" method="post">
+	{% else %}
+	<p>Your request to mentor this project is under review by the community coordinator.</p>
+	{% endif %}
+	<form action="{% url 'project-mentor-status' community_slug=community.slug project_slug=project.slug mentor_id=mentor_request.mentor_id %}" method="post">
 		{% csrf_token %}
 		<input class="btn btn-warning" type="submit" name="reject" value="Withdraw From Mentoring" />
 	</form>
-{% else %}
-	<form action="{% url 'project-mentor-status' community_slug=community.slug project_slug=project.slug mentor_id=comrade.account_id %}" method="post">
+{% elif request.user.comrade %}
+	<form action="{% url 'project-mentor-status' community_slug=community.slug project_slug=project.slug mentor_id=request.user.comrade.pk %}" method="post">
 		{% csrf_token %}
 		<input class="btn btn-success" type="submit" name="add" value="Mentor This Project" />
 	</form>

--- a/home/views.py
+++ b/home/views.py
@@ -272,10 +272,11 @@ class CommunityUpdate(LoginRequiredMixin, UpdateView):
 
     def get_object(self):
         community = super(CommunityUpdate, self).get_object()
-        if not community.coordinatorapproval_set.filter(approved=True, coordinator__account=self.request.user).exists():
+        if not community.is_coordinator(self.request.user):
             raise PermissionDenied("You are not an approved coordinator for this community.")
         return community
 
+# Only Outreachy organizers are allowed to approve communities.
 @require_POST
 @staff_member_required
 def community_status_change(request, community_slug):
@@ -306,7 +307,7 @@ class ParticipationUpdateView(LoginRequiredMixin, UpdateView):
     # community participating in the current round.
     def get_object(self):
         community = get_object_or_404(Community, slug=self.kwargs['slug'])
-        if not community.coordinatorapproval_set.filter(approved=True, coordinator__account=self.request.user).exists():
+        if not community.is_coordinator(self.request.user):
             raise PermissionDenied("You are not an approved coordinator for this community.")
 
         participating_round = RoundPage.objects.latest('internstarts')
@@ -395,10 +396,14 @@ class ProjectUpdate(LoginRequiredMixin, ComradeRequiredMixin, UpdateView):
                     community__slug=self.kwargs['community_slug'],
                     participating_round=participating_round)
         if 'project_slug' in self.kwargs:
-            return get_object_or_404(Project,
+            project = get_object_or_404(Project,
                     project_round=participation,
                     slug=self.kwargs['project_slug'])
+            if not (project.is_mentor(self.request.user) or participation.community.is_coordinator(self.request.user)):
+                raise PermissionDenied("You are not an approved mentor for this project.")
+            return project
         else:
+            # Everyone is allowed to propose projects.
             return Project(project_round=participation)
 
     def form_valid(self, form):
@@ -416,14 +421,18 @@ class ProjectUpdate(LoginRequiredMixin, ComradeRequiredMixin, UpdateView):
                 community_slug=self.object.project_round.community.slug)
 
 @require_POST
+@login_required
 def project_status_change(request, community_slug, project_slug):
     current_round = RoundPage.objects.latest('internstarts')
     project = get_object_or_404(
-            Project,
+            Project.objects.select_related('project_round__community'),
             slug=project_slug,
             project_round__participating_round=current_round,
             project_round__community__slug=community_slug,
             )
+
+    if not project.project_round.community.is_coordinator(request.user):
+        raise PermissionDenied("You are not an approved coordinator for this community.")
 
     if 'approve' in request.POST:
         project.list_project = True
@@ -436,30 +445,42 @@ def project_status_change(request, community_slug, project_slug):
             project_slug=project_slug,
             community_slug=community_slug)
 
-# Only superusers and the coordinator for the community should be able to approve project mentors.
+# Each of add/approve/reject requires different permissions, so read
+# this carefully.
 @require_POST
+@login_required
 def project_mentor_update(request, community_slug, project_slug, mentor_id):
     current_round = RoundPage.objects.latest('internstarts')
     project = get_object_or_404(
-            Project,
+            Project.objects.select_related('project_round__community'),
             slug=project_slug,
             project_round__participating_round=current_round,
             project_round__community__slug=community_slug,
             )
 
-    # If this user doesn't have a Comrade object, we'd like to help them
-    # by redirecting to the ComradeUpdate form. But because this is a
-    # POST request, we can't. This should be rare, so just 404.
+    # If this user doesn't have a Comrade object and wants to add
+    # themself as a mentor, we'd like to help them by redirecting to the
+    # ComradeUpdate form. (Approve and reject actions are guaranteed to
+    # have a Comrade already so they're fine, at least.) But because
+    # this is a POST request, we can't. This should be rare; just 404.
     mentor = get_object_or_404(Comrade, pk=mentor_id)
 
+    is_self = (mentor.account_id == request.user.id)
+
     if 'add' in request.POST:
+        if not is_self:
+            raise PermissionDenied("Hey, no fair volunteering other people without their consent!")
         mentor_status = MentorApproval(mentor=mentor, project=project, approved=False)
         mentor_status.save()
     if 'approve' in request.POST:
+        if not project.project_round.community.is_coordinator(request.user):
+            raise PermissionDenied("You are not an approved coordinator for this community.")
         mentor_status = get_object_or_404(MentorApproval, mentor=mentor, project=project)
         mentor_status.approved = True
         mentor_status.save()
     if 'reject' in request.POST:
+        if not (is_self or project.project_round.community.is_coordinator(request.user)):
+            raise PermissionDenied("You are not an approved coordinator for this community.")
         mentor_status = get_object_or_404(MentorApproval, mentor=mentor, project=project)
         # Yeah, this could be a NullBooleanField and we could tell mentors
         # that they have been rejected, but TBH I'm running out of time to fix this.
@@ -475,21 +496,31 @@ def community_coordinator_update(request, community_slug, coordinator_id):
     current_round = RoundPage.objects.latest('internstarts')
     community = get_object_or_404(Community, slug=community_slug)
 
-    # FIXME: redirect to a Comrade creation view with next pointing back to this
+    # See comment in project_mentor_update for why we just 404.
     coordinator = get_object_or_404(Comrade, account_id=coordinator_id)
 
+    is_self = (coordinator.account_id == request.user.id)
+
     if 'add' in request.POST:
+        if not is_self:
+            raise PermissionDenied("Hey, no fair volunteering other people without their consent!")
         coordinator_status = CoordinatorApproval(coordinator=coordinator, community=community, approved=None)
         coordinator_status.save()
     if 'approve' in request.POST:
+        if not (request.user.is_staff or community.is_coordinator(request.user)):
+            raise PermissionDenied("You are not an approved coordinator for this community.")
         coordinator_status = get_object_or_404(CoordinatorApproval, coordinator=coordinator, community=community)
         coordinator_status.approved = True
         coordinator_status.save()
     if 'reject' in request.POST:
+        if not (request.user.is_staff or community.is_coordinator(request.user)):
+            raise PermissionDenied("You are not an approved coordinator for this community.")
         coordinator_status = get_object_or_404(CoordinatorApproval, coordinator=coordinator, community=community)
         coordinator_status.approved = False
         coordinator_status.save()
     if 'withdraw' in request.POST:
+        if not is_self:
+            raise PermissionDenied("You can only withdraw yourself, not other people.")
         coordinator_status = get_object_or_404(CoordinatorApproval, coordinator=coordinator, community=community)
         coordinator_status.delete()
 

--- a/home/views.py
+++ b/home/views.py
@@ -375,7 +375,7 @@ def project_read_only_view(request, community_slug, project_slug):
             },
             )
 
-class ProjectUpdate(LoginRequiredMixin, UpdateView):
+class ProjectUpdate(LoginRequiredMixin, ComradeRequiredMixin, UpdateView):
     model = Project
     fields = ['short_title', 'longevity', 'community_size', 'approved_license', 'accepting_new_applicants']
 


### PR DESCRIPTION
At this point every needed permissions check should have a corresponding `PermissionDenied` exception raised under appropriate conditions. The templates should be reviewed to avoid generating links that will fail permissions checks, and to ensure that links appear somewhere if the user has permission for them.