### PR TITLE
fix missing pending coordinators

### DIFF
--- a/home/models.py
+++ b/home/models.py
@@ -951,4 +951,4 @@ class CoordinatorApproval(ApprovalStatus):
     def objects_for_dashboard(cls, user):
         if user.is_staff:
             return cls.objects.all()
-        return cls.objects.filter(coordinator__account=user)
+        return cls.objects.filter(community__coordinatorapproval__coordinator__account=user)


### PR DESCRIPTION
This closes #81. 

After @madprime's comments I cloned a copy of the repo to figure out the problem for myself (my own curiosity got me after all 😉). 

After setting up my local development environment I managed to create a test project with `user account A` and requesting coordinator approval with `user account B` the pending request did not show up on the `dashboard`, so it wasn't completely my fault. It turned out that the `filter` criteria was wrong, the correct filtering would be on `community__coordinatorapproval__coordinator__account`, this gives the expected coordinator view. 

Hope that helps!