### PR TITLE
Fix squished display of sponsor logos.

### DIFF
--- a/home/templates/home/blocks/logo.html
+++ b/home/templates/home/blocks/logo.html
@@ -1,2 +1,2 @@
 {% load wagtailimages_tags %}
-<center>{% image value max-200x200 style="padding-top:20px; padding-left:30px;" %}</center>
+<center>{% image value max-200x200 style="margin-top:20px; margin-left:30px;" %}</center>


### PR DESCRIPTION
The rendering of the sponsor logos was double-constrained: we get a
200x200px image from the backend, and tell the browser we want a 200x200 box
with width and height properties, but then we put padding in that box and
render the logo in the remaining space.  This causes logos to appear squished.

Prefer margins to padding, which are outside the 200x200 box and so don't
intrude on the logo rendering space.  Since each logo is rendered in its own
div, the switch to margins doesn't cause larger knock-off effects on the
page box model.