### PR TITLE
Fix typo on /apply/eligibility/

### DIFF
--- a/home/templates/home/eligibility.html
+++ b/home/templates/home/eligibility.html
@@ -22,7 +22,7 @@
 	<li>You must meet one of the following criteria:</li>
 	<ul>
 		<li>You live any where in the world and you identify as a woman (cis or trans), trans man, or genderqueer person (including genderfluid or genderfree).</li>
-		<li>You live in the United States or you are a U.S. national or permanent resident living aboard, AND you are a person of any gender who is Black/African American, Hispanic/Latin@, Native American/American Indian, Alaska Native, Native Hawaiian, or Pacific Islander</li>
+		<li>You live in the United States or you are a U.S. national or permanent resident living abroad, AND you are a person of any gender who is Black/African American, Hispanic/Latin@, Native American/American Indian, Alaska Native, Native Hawaiian, or Pacific Islander</li>
 	</ul>
 	<li>Outreachy is open to both students and people who are not students. However, applicants who are students must meet additional requirements.</li>
 	<li>Outreachy internships are full-time 40-hour a week internships. Applicants who have part-time or contracting jobs are welcome to apply, but they must meet additional requirements.


### PR DESCRIPTION
This PR is in reference to the issue #159.
Changed ```aboard ``` to ```abroad```
