### PR TITLE
README now recommends using the Wagtail interface when creating a round page

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ PATH="$PWD/node_modules/.bin:$PATH" ./manage.py runserver
 
 In your web browser, go to `http://localhost:8000/admin/` to get to the Wagtail administrative interface. `http://localhost:8000/django-admin/` takes you to the regular Django administrative interface. You can log in into both with the account you created with `./manage.py createsuperuser`. 
 
-If you want to create participating communities, project proposals etc. you first need to set up a `RoundPage`. An easy way to do so is from the *Django administrative interface*. To do this navigate to `http://127.0.0.1:8000/django-admin/home/roundpage/add/`, login with the `superuser` account and fill out the necessary fields: `path`,`depth`,`title`,`slug`,`content-type` (should be `round page`), `owner`, `page title` and `Roundnumber`. All other fields can be run with the defaults. Afterwards you can navigate to `http://127.0.0.1:8000/communities/cfp/` to see the current round. 
+If you want to create participating communities, project proposals etc. you first need to set up a `RoundPage`. An easy way to do so is from the *Wagtail interface*. To do this navigate to `http://127.0.0.1:8000/admin` and login with the `superuser` account. On the left menu, click on `Pages` and then on the `Home` directory. Press `Add child page`, select `Round page` and fill out the necessary fields (such as `title`, `roundnumber`, `slug`). All other fields can be run with the defaults. Afterwards you can navigate to `http://127.0.0.1:8000/communities/cfp/` to see the current round.
 
 # Django shell
 


### PR DESCRIPTION
Setting up a round page through the django-admin interface may cause those who follow the documentation to stumble upon the ['str' object has no attribute 'utcoffset'](https://gist.github.com/contraexemplo/22e5570f943b6815df8e2ef63f973bdd) error. A way to avoid it is using the Wagtail interface to create a round page, as recommended by @sagesharp in a conversation about that error. The README has been updated to recommend that path instead. :tada: 

Question: am I right about the reader selecting the `Home` repository as it is set as root by default on the existing local website? I was a bit hesitant to add that part. Feel free to add as many suggestions as needed.